### PR TITLE
feat: 시간표 페이지에서 담당 선생님 표시

### DIFF
--- a/src/components/Timetable/TimetableItem.tsx
+++ b/src/components/Timetable/TimetableItem.tsx
@@ -9,13 +9,16 @@ const DayText = styled.p<{ active?: boolean }>`
   color: ${(props) => (props.active ? 'var(--color-button-hover)' : 'black')};
 `;
 
-const SubjectText = styled.p<{ active?: boolean }>`
+const SubjectText = styled.p<{ active?: boolean, showTeacher?: boolean }>`
   font-size: 14px;
   white-space: nowrap;
+  
+  margin-top: ${(props) => props.showTeacher ? '10px' : '0'};
 
   font-weight: ${(props) => (props.active ? 'bold' : 'none')};
 
   cursor: pointer;
+
   &:hover {
     text-decoration: underline;
   }
@@ -25,9 +28,10 @@ interface TimetableItemProps {
   readonly day: string;
   readonly data: ComciganTimetableType[];
   readonly active?: boolean;
+  readonly showTeacher?: boolean;
 }
 
-const TimetableItem: React.FC<TimetableItemProps> = ({ day, data, active }) => {
+const TimetableItem: React.FC<TimetableItemProps> = ({ day, data, active, showTeacher }) => {
   const onClick = (url: string | null) => {
     if (!url) {
       showToast('수업 링크가 등록되어 있지 않습니다.', 'danger');
@@ -41,16 +45,23 @@ const TimetableItem: React.FC<TimetableItemProps> = ({ day, data, active }) => {
     <div>
       <DayText active={active}>{day}</DayText>
       {data &&
-        data.map((value, index) => (
-          <SubjectText
-            // eslint-disable-next-line react/no-array-index-key
-            key={`${value.weekday}${index}${value.code}`}
-            onClick={() => onClick(value.url)}
-            active={active}
-          >
-            {value.subject}
-          </SubjectText>
-        ))}
+      data.map((value, index) => (
+        <SubjectText
+          // eslint-disable-next-line react/no-array-index-key
+          key={`${value.weekday}${index}${value.code}`}
+          onClick={() => onClick(value.url)}
+          active={active}
+          showTeacher={showTeacher}
+        >
+          {value.subject}
+          {(showTeacher && value.teacher.trim() !== "*") && (
+            <>
+              <br />
+              ({value.teacher})
+            </>
+          )}
+        </SubjectText>
+      ))}
     </div>
   );
 };

--- a/src/pages/TimetablePage.tsx
+++ b/src/pages/TimetablePage.tsx
@@ -69,6 +69,7 @@ const TimetablePage: React.FC = () => {
                 day={`${day[index + 1]}`}
                 data={value}
                 active={index + 1 === today}
+                showTeacher
               />
             ))}
           </TimetableList>


### PR DESCRIPTION
## 😎 어떤 기능이 추가되거나 변경되었나요?
- 시간표 페이지에서 담당 선생님을 표시합니다. 메인 페이지 시간표 카드에서는 표시하지 않습니다.

## ❗ 주의하거나 참고할 점이 있나요?
- `showTeacher` prop으로 담당 선생님 표시 여부를 결정할 수 있습니다.
